### PR TITLE
add @Override to onSampledInTrackPoint

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java
@@ -202,6 +202,7 @@ public class ChartFragment extends Fragment implements TrackDataHub.Listener {
         }
     }
 
+    @Override
     public void onSampledInTrackPoint(@NonNull TrackPoint trackPoint, @NonNull TrackStatistics trackStatistics) {
         if (isResumed()) {
             ChartPoint point = ChartPoint.create(trackStatistics, trackPoint, trackPoint.getSpeed(), chartByDistance, viewBinding.chartView.getUnitSystem());


### PR DESCRIPTION
This PR contains changes to add an @Override to the onSampledInTrackPoint method

Source file: src/main/java/de/dennisguse/opentracks/chart/ChartFragment.java

Link to issue: https://github.com/soen6431-winter25/OpenTracksW25/issues/15
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `@Override` annotation to `onSampledInTrackPoint()` in `ChartFragment.java`.
> 
>   - **Annotations**:
>     - Add `@Override` to `onSampledInTrackPoint()` in `ChartFragment.java` to indicate method overrides `TrackDataHub.Listener` interface.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for 6a96c927db374f8985a0b18f285926774da3d328. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->