### PR TITLE
add dedicated exception class

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -258,9 +258,9 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
             super(fa);
         }
 
-        public class InvalidFragmentPositionException extends IllegalArgumentException {
+        private static class InvalidFragmentPositionException extends IllegalArgumentException {
             public InvalidFragmentPositionException(int position) {
-                super("There isn't a Fragment associated with the position: " + position);
+                super("There isn't a Fragment associated with the position: " + position + ". Expected between 0 and 3.");
             }
         }
 

--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -258,6 +258,12 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
             super(fa);
         }
 
+        public class InvalidFragmentPositionException extends IllegalArgumentException {
+            public InvalidFragmentPositionException(int position) {
+                super("There isn't a Fragment associated with the position: " + position);
+            }
+        }
+
         @NonNull
         @Override
         public Fragment createFragment(int position) {
@@ -267,7 +273,7 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
                 case 2 -> ChartFragment.newInstance(false);
                 case 3 -> ChartFragment.newInstance(true);
                 default ->
-                        throw new RuntimeException("There isn't Fragment associated with the position: " + position);
+                        throw new InvalidFragmentPositionException(position);
             };
         }
 
@@ -283,7 +289,7 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
                 case 2 -> getString(R.string.settings_chart_by_time);
                 case 3 -> getString(R.string.settings_chart_by_distance);
                 default ->
-                        throw new RuntimeException("There isn't Fragment associated with the position: " + position);
+                        throw new InvalidFragmentPositionException(position);
             };
         }
     }


### PR DESCRIPTION
This pull request contains changes to add a dedicated exception handling class instead of using generic exception class

Source file: src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java

Link to issue: [#17 ](https://github.com/soen6431-winter25/OpenTracksW25/issues/17)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduced `InvalidFragmentPositionException` in `CustomFragmentPagerAdapter` to replace `RuntimeException` for invalid fragment positions in `TrackRecordedActivity.java`.
> 
>   - **Exception Handling**:
>     - Introduced `InvalidFragmentPositionException` in `CustomFragmentPagerAdapter` to replace `RuntimeException` for invalid fragment positions.
>     - Updated `createFragment()` and `getPageTitle()` methods to throw `InvalidFragmentPositionException` instead of `RuntimeException`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for a6949dc1ab07cb08f65d1cb35d99ee3259996cd3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->