### PR TITLE
add overrides for array

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/SelectionData.java
+++ b/src/main/java/de/dennisguse/opentracks/data/SelectionData.java
@@ -1,11 +1,37 @@
 package de.dennisguse.opentracks.data;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public record SelectionData(
-        String selection,
-        String[] selectionArgs
+    String selection,
+    String[] selectionArgs
 ) {
 
     public SelectionData() {
         this(null, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SelectionData that = (SelectionData) o;
+        return Objects.equals(selection, that.selection) && Arrays.equals(selectionArgs, that.selectionArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(selection);
+        result = 31 * result + Arrays.hashCode(selectionArgs);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "SelectionData{" +
+                "selection='" + selection + '\'' +
+                ", selectionArgs=" + Arrays.toString(selectionArgs) +
+                '}';
     }
 }


### PR DESCRIPTION
This pull request contains changes to implement overrides for "equals()", "hashCode()" and "toString()" methods for arrays.

Source file: src/main/java/de/dennisguse/opentracks/data/SelectionData.java

Link to issue: [https://github.com/soen6431-winter25/OpenTracksW25/issues/19](https://github.com/soen6431-winter25/OpenTracksW25/issues/19)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add overrides for `equals()`, `hashCode()`, and `toString()` in `SelectionData` to handle arrays correctly.
> 
>   - **Overrides in `SelectionData`**:
>     - Implement `equals()` to compare `selection` and `selectionArgs` using `Objects.equals()` and `Arrays.equals()`.
>     - Implement `hashCode()` to compute hash using `Objects.hash()` and `Arrays.hashCode()`.
>     - Implement `toString()` to format `selection` and `selectionArgs` using `Arrays.toString()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for c011f9da0e0e1ca0b778618a7f04675ade8ce2db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->