### PR TITLE
merged if statement to avoid nested statements

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java
@@ -148,10 +148,9 @@ public abstract class DirectoryChooserActivity extends AppCompatActivity {
         protected DocumentFile configureDirectoryChooserIntent(Intent intent) {
             super.configureDirectoryChooserIntent(intent);
             intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-            if (PreferencesUtils.isDefaultExportDirectoryUri()) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, PreferencesUtils.getDefaultExportDirectoryUri());
-                }
+            if (PreferencesUtils.isDefaultExportDirectoryUri()
+                    && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, PreferencesUtils.getDefaultExportDirectoryUri());
             }
             return null;
         }


### PR DESCRIPTION
This pull request addresses nested if statements and merges them into the enclosing one to improve readability and maintainability.

Source file: src/main/java/de/dennisguse/opentracks/io/file/importer/DirectoryChooserActivity.java

Link to Issue: https://github.com/soen6431-winter25/OpenTracksW25/issues/23
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplified nested `if` statements in `configureDirectoryChooserIntent()` of `DirectoryChooserActivity.java` for better readability.
> 
>   - **Code Simplification**:
>     - Merged nested `if` statements into a single condition in `configureDirectoryChooserIntent()` of `DirectoryChooserActivity.java` to improve readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for b6e6d10ce5980708e0c5e031dc7130e296ab5b6e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->