### PR TITLE
define a constant instead of duplicating literal " * (COALESCE(MAX(t." 3 times

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -56,6 +56,8 @@ public class CustomContentProvider extends ContentProvider {
 
     private static final int TOTAL_DELETED_ROWS_VACUUM_THRESHOLD = 10000;
 
+    private final String COALESCE_MAX = " * (COALESCE(MAX(t.";
+
     private final UriMatcher uriMatcher;
 
     private SQLiteDatabase db;
@@ -72,19 +74,19 @@ public class CustomContentProvider extends ContentProvider {
                 "WHERE t1." + TrackPointsColumns._ID + " > t." + TrackPointsColumns._ID + " AND t1." + TrackPointsColumns.TRACKID + " = ? ORDER BY _id LIMIT 1) " +
 
             "SELECT " +
-                "SUM(t." + TrackPointsColumns.SENSOR_HEARTRATE + " * (COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_HEARTRATE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
                 "/ " +
                 "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_HR + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_HEARTRATE + ") " + TrackPointsColumns.ALIAS_MAX_HR + ", " +
 
-                "SUM(t." + TrackPointsColumns.SENSOR_CADENCE + " * (COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_CADENCE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
                 "/ " +
                 "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_CADENCE + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_CADENCE + ") " + TrackPointsColumns.ALIAS_MAX_CADENCE + ", " +
 
-                "SUM(t." + TrackPointsColumns.SENSOR_POWER + " * (COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_POWER + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
                 "/ " +
                 "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_POWER + ", " +
 

--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -56,7 +56,7 @@ public class CustomContentProvider extends ContentProvider {
 
     private static final int TOTAL_DELETED_ROWS_VACUUM_THRESHOLD = 10000;
 
-    private final String COALESCE_MAX = " * (COALESCE(MAX(t.";
+    private static final String COALESCE_MAX = " * (COALESCE(MAX(t.";
 
     private final UriMatcher uriMatcher;
 

--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -60,6 +60,8 @@ public class CustomContentProvider extends ContentProvider {
 
     private static final String T_TRACKPOINTSCOLUMNS = ") - t.";
 
+    private static final String SELECT_TIME_VALUE = ", (SELECT time_value FROM time_select)), t.";
+
     private final UriMatcher uriMatcher;
 
     private SQLiteDatabase db;
@@ -76,21 +78,21 @@ public class CustomContentProvider extends ContentProvider {
                 "WHERE t1." + TrackPointsColumns._ID + " > t." + TrackPointsColumns._ID + " AND t1." + TrackPointsColumns.TRACKID + " = ? ORDER BY _id LIMIT 1) " +
 
             "SELECT " +
-                "SUM(t." + TrackPointsColumns.SENSOR_HEARTRATE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_HEARTRATE + COALESCE_MAX + TrackPointsColumns.TIME + SELECT_TIME_VALUE + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
                 "/ " +
-                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_HR + ", " +
+                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + SELECT_TIME_VALUE + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_HR + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_HEARTRATE + ") " + TrackPointsColumns.ALIAS_MAX_HR + ", " +
 
-                "SUM(t." + TrackPointsColumns.SENSOR_CADENCE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_CADENCE + COALESCE_MAX + TrackPointsColumns.TIME + SELECT_TIME_VALUE + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
                 "/ " +
-                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_CADENCE + ", " +
+                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + SELECT_TIME_VALUE + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_CADENCE + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_CADENCE + ") " + TrackPointsColumns.ALIAS_MAX_CADENCE + ", " +
 
-                "SUM(t." + TrackPointsColumns.SENSOR_POWER + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_POWER + COALESCE_MAX + TrackPointsColumns.TIME + SELECT_TIME_VALUE + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
                 "/ " +
-                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_POWER + ", " +
+                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + SELECT_TIME_VALUE + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_POWER + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_POWER + ") " + TrackPointsColumns.ALIAS_MAX_POWER + " " +
 

--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -58,6 +58,8 @@ public class CustomContentProvider extends ContentProvider {
 
     private static final String COALESCE_MAX = " * (COALESCE(MAX(t.";
 
+    private static final String T_TRACKPOINTSCOLUMNS = ") - t.";
+
     private final UriMatcher uriMatcher;
 
     private SQLiteDatabase db;
@@ -74,21 +76,21 @@ public class CustomContentProvider extends ContentProvider {
                 "WHERE t1." + TrackPointsColumns._ID + " > t." + TrackPointsColumns._ID + " AND t1." + TrackPointsColumns.TRACKID + " = ? ORDER BY _id LIMIT 1) " +
 
             "SELECT " +
-                "SUM(t." + TrackPointsColumns.SENSOR_HEARTRATE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_HEARTRATE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
                 "/ " +
-                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_HR + ", " +
+                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_HR + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_HEARTRATE + ") " + TrackPointsColumns.ALIAS_MAX_HR + ", " +
 
-                "SUM(t." + TrackPointsColumns.SENSOR_CADENCE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_CADENCE + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
                 "/ " +
-                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_CADENCE + ", " +
+                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_CADENCE + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_CADENCE + ") " + TrackPointsColumns.ALIAS_MAX_CADENCE + ", " +
 
-                "SUM(t." + TrackPointsColumns.SENSOR_POWER + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ")) " +
+                "SUM(t." + TrackPointsColumns.SENSOR_POWER + COALESCE_MAX + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ")) " +
                 "/ " +
-                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + ") - t." + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_POWER + ", " +
+                "SUM(COALESCE(MAX(t." + TrackPointsColumns.TIME + ", (SELECT time_value FROM time_select)), t." + TrackPointsColumns.TIME + T_TRACKPOINTSCOLUMNS + TrackPointsColumns.TIME + ") " + TrackPointsColumns.ALIAS_AVG_POWER + ", " +
 
                 "MAX(t." + TrackPointsColumns.SENSOR_POWER + ") " + TrackPointsColumns.ALIAS_MAX_POWER + " " +
 


### PR DESCRIPTION
This PR contains changes to define a constant for the "(COALESCE(MAX(t." string that is duplicated three times. 

Source file: src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java

Link to issue: https://github.com/soen6431-winter25/OpenTracksW25/issues/25
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Define constants for repeated SQL string literals in `CustomContentProvider.java` to improve code maintainability.
> 
>   - **Constants**:
>     - Define `COALESCE_MAX` for the string `" * (COALESCE(MAX(t."`.
>     - Define `T_TRACKPOINTSCOLUMNS` for the string `") - t."`.
>   - **Refactoring**:
>     - Replace repeated string literals in `SENSOR_STATS_QUERY` with the new constants `COALESCE_MAX` and `T_TRACKPOINTSCOLUMNS` in `CustomContentProvider.java`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for df5c8eeea4d7835b75e396a6ed7e08de6e26f4dc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->