### PR TITLE
Defined a constant and replace UNKNOWN URL string

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -56,6 +56,8 @@ public class CustomContentProvider extends ContentProvider {
 
     private static final int TOTAL_DELETED_ROWS_VACUUM_THRESHOLD = 10000;
 
+    private static final String UNKNOWN_URL = "Unknown URL ";
+
     private final UriMatcher uriMatcher;
 
     private SQLiteDatabase db;
@@ -139,7 +141,7 @@ public class CustomContentProvider extends ContentProvider {
             case TRACKPOINTS -> TrackPointsColumns.TABLE_NAME;
             case TRACKS -> TracksColumns.TABLE_NAME;
             case MARKERS -> MarkerColumns.TABLE_NAME;
-            default -> throw new IllegalArgumentException("Unknown URL " + url);
+            default -> throw new IllegalArgumentException(UNKNOWN_URL + url);
         };
 
         Log.w(TAG, "Deleting from table " + table);
@@ -187,7 +189,7 @@ public class CustomContentProvider extends ContentProvider {
             case TRACKS_BY_ID -> TracksColumns.CONTENT_ITEMTYPE;
             case MARKERS -> MarkerColumns.CONTENT_TYPE;
             case MARKERS_BY_ID, MARKERS_BY_TRACKID -> MarkerColumns.CONTENT_ITEMTYPE;
-            default -> throw new IllegalArgumentException("Unknown URL " + url);
+            default -> throw new IllegalArgumentException(UNKNOWN_URL + url);
         };
     }
 
@@ -276,7 +278,7 @@ public class CustomContentProvider extends ContentProvider {
                 queryBuilder.setTables(MarkerColumns.TABLE_NAME);
                 queryBuilder.appendWhere(MarkerColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
             }
-            default -> throw new IllegalArgumentException("Unknown url " + url);
+            default -> throw new IllegalArgumentException(UNKNOWN_URL + url);
         }
         Cursor cursor = queryBuilder.query(db, projection, selection, selectionArgs, null, null, sortOrder);
         cursor.setNotificationUri(getContext().getContentResolver(), url);
@@ -322,7 +324,7 @@ public class CustomContentProvider extends ContentProvider {
                     whereClause += " AND (" + where + ")";
                 }
             }
-            default -> throw new IllegalArgumentException("Unknown url " + url);
+            default -> throw new IllegalArgumentException(UNKNOWN_URL + url);
         }
         int count;
         try {
@@ -344,7 +346,7 @@ public class CustomContentProvider extends ContentProvider {
             return urlTypes[matchIndex];
         }
 
-        throw new IllegalArgumentException("Unknown URL " + url);
+        throw new IllegalArgumentException(UNKNOWN_URL + url);
     }
 
     /**
@@ -359,7 +361,7 @@ public class CustomContentProvider extends ContentProvider {
             case TRACKPOINTS -> insertTrackPoint(url, contentValues);
             case TRACKS -> insertTrack(url, contentValues);
             case MARKERS -> insertMarker(url, contentValues);
-            default -> throw new IllegalArgumentException("Unknown url " + url);
+            default -> throw new IllegalArgumentException(UNKNOWN_URL + url);
         };
     }
 


### PR DESCRIPTION
This PR contains changes to define a constant instead of duplicating this literal "Unknown URL " 3 times.

Source file: src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java

Link to issue: https://github.com/soen6431-winter25/OpenTracksW25/issues/27
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Define `UNKNOWN_URL` constant in `CustomContentProvider.java` to replace repeated string literals.
> 
>   - **Constants**:
>     - Define `UNKNOWN_URL` constant in `CustomContentProvider.java` to replace repeated "Unknown URL " string.
>   - **Usage**:
>     - Replace string literal with `UNKNOWN_URL` in `delete()`, `getType()`, `query()`, `update()`, `getUrlType()`, and `insertContentValues()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for 2166e89d1d88a97910c0cdd5a175b413a2ec5d10. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->