### PR TITLE
Fix this access on a collection that may trigger an ArrayIndexOutOfBo…

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -364,10 +364,15 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
         }
 
         if (itemId == R.id.list_context_menu_edit) {
-            Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
-                    .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
-            startActivity(intent);
-            return true;
+            if (trackIds.length > 0) {
+                Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
+                        .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
+                startActivity(intent);
+                return true;
+            }
+            else {
+                return false;
+            }
         }
 
         if (itemId == R.id.list_context_menu_delete) {


### PR DESCRIPTION

**Describe the pull request**
Fix access on a collection that may trigger an 'ArrayIndexOutOfBoundsException'

**Link to the the issue**
https://github.com/soen6431-winter25/OpenTracksW25/issues/8

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix potential `ArrayIndexOutOfBoundsException` in `TrackListActivity.java` by checking array length before access.
> 
>   - **Behavior**:
>     - Fix potential `ArrayIndexOutOfBoundsException` in `handleContextItem()` in `TrackListActivity.java` by checking `trackIds.length > 0` before accessing `trackIds[0]`.
>     - Returns `false` if `trackIds` is empty when `itemId` is `R.id.list_context_menu_edit`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for 417eabf6813626b09992dbff2464e4ec4c6c454e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->