### PR TITLE
Tech debt/add private constructor - corrected variable spelling error

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/UUIDUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/UUIDUtils.java
@@ -15,7 +15,7 @@ public class UUIDUtils {
     public static UUID fromBytes(byte[] bytes) {
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
         long mostSignificant = byteBuffer.getLong();
-        long leastSignificant = byteBuffer.getLong();
+        long lestSignificant = byteBuffer.getLong();
         return new UUID(mostSignificant, lestSignificant);
     }
 


### PR DESCRIPTION
This pull request contains changes to correct the spelling of a variable used in the UUIDUtils class.

Source file: src/main/java/de/dennisguse/opentracks/data/UUIDUtils.java

Line number: 18
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects spelling of variable `leastSignificant` to `lestSignificant` in `fromBytes()` method in `UUIDUtils.java`.
> 
>   - **Code Correction**:
>     - Corrects spelling of variable `leastSignificant` to `lestSignificant` in `fromBytes()` method in `UUIDUtils.java`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for b1fb6856a67d97bcb1e38646c21832a09871b12a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->