### PR TITLE
Define WHERE and SELECT_MAX constants in ContentProviderUtils.java

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
@@ -68,6 +68,7 @@ public class ContentProviderUtils {
     private static final String TAG = ContentProviderUtils.class.getSimpleName();
     private static final String LIKE_OR = " LIKE ? OR ";
     private static final String WHERE = " WHERE ";
+    private static final String SELECT_MAX = "=(SELECT MAX(";
 
     // The authority (the first part of the URI) for the app's content provider.
     @VisibleForTesting
@@ -680,7 +681,7 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint.Id getLastTrackPointId(@NonNull Track.Id trackId) {
-        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") from " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=?)";
+        String selection = TrackPointsColumns._ID + SELECT_MAX + TrackPointsColumns._ID + ") from " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.id())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
             if (cursor != null && cursor.moveToFirst()) {
@@ -699,7 +700,7 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint.Id getTrackPointId(Track.Id trackId, Location location) {
-        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TIME + "=?)";
+        String selection = TrackPointsColumns._ID + SELECT_MAX + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TIME + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.id()), Long.toString(location.getTime())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
             if (cursor != null && cursor.moveToFirst()) {
@@ -747,7 +748,7 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint getLastValidTrackPoint(Track.Id trackId) {
-        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TYPE + " IN (" + TrackPoint.Type.SEGMENT_START_AUTOMATIC.type_db + "," + TrackPoint.Type.TRACKPOINT.type_db + "))";
+        String selection = TrackPointsColumns._ID + SELECT_MAX + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TYPE + " IN (" + TrackPoint.Type.SEGMENT_START_AUTOMATIC.type_db + "," + TrackPoint.Type.TRACKPOINT.type_db + "))";
         String[] selectionArgs = new String[]{Long.toString(trackId.id())};
         return findTrackPointBy(selection, selectionArgs);
     }

--- a/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java
@@ -67,6 +67,7 @@ public class ContentProviderUtils {
 
     private static final String TAG = ContentProviderUtils.class.getSimpleName();
     private static final String LIKE_OR = " LIKE ? OR ";
+    private static final String WHERE = " WHERE ";
 
     // The authority (the first part of the URI) for the app's content provider.
     @VisibleForTesting
@@ -679,7 +680,7 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint.Id getLastTrackPointId(@NonNull Track.Id trackId) {
-        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") from " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=?)";
+        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") from " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.id())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
             if (cursor != null && cursor.moveToFirst()) {
@@ -698,7 +699,7 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint.Id getTrackPointId(Track.Id trackId, Location location) {
-        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TIME + "=?)";
+        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TIME + "=?)";
         String[] selectionArgs = new String[]{Long.toString(trackId.id()), Long.toString(location.getTime())};
         try (Cursor cursor = getTrackPointCursor(new String[]{TrackPointsColumns._ID}, selection, selectionArgs, TrackPointsColumns._ID)) {
             if (cursor != null && cursor.moveToFirst()) {
@@ -746,7 +747,7 @@ public class ContentProviderUtils {
      */
     @Deprecated
     public TrackPoint getLastValidTrackPoint(Track.Id trackId) {
-        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + " WHERE " + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TYPE + " IN (" + TrackPoint.Type.SEGMENT_START_AUTOMATIC.type_db + "," + TrackPoint.Type.TRACKPOINT.type_db + "))";
+        String selection = TrackPointsColumns._ID + "=(SELECT MAX(" + TrackPointsColumns._ID + ") FROM " + TrackPointsColumns.TABLE_NAME + WHERE + TrackPointsColumns.TRACKID + "=? AND " + TrackPointsColumns.TYPE + " IN (" + TrackPoint.Type.SEGMENT_START_AUTOMATIC.type_db + "," + TrackPoint.Type.TRACKPOINT.type_db + "))";
         String[] selectionArgs = new String[]{Long.toString(trackId.id())};
         return findTrackPointBy(selection, selectionArgs);
     }


### PR DESCRIPTION
This PR contains changes to define a constant instead of duplicating this literal " WHERE " 3 times.

Source file: src/main/java/de/dennisguse/opentracks/data/ContentProviderUtils.java

Link to issue: https://github.com/soen6431-winter25/OpenTracksW25/issues/35
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Define `WHERE` and `SELECT_MAX` constants in `ContentProviderUtils.java` to replace repeated SQL string literals.
> 
>   - **Constants**:
>     - Define `WHERE` constant in `ContentProviderUtils.java` to replace repeated " WHERE " string.
>     - Define `SELECT_MAX` constant for repeated "=(SELECT MAX(" string.
>   - **Code Refactoring**:
>     - Replace literal " WHERE " with `WHERE` constant in `getLastTrackPointId()`, `getTrackPointId()`, and `getLastValidTrackPoint()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for 15a476d1025a48938902561eaeb0658edb16065a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->