### PR TITLE
adds drop index tracks_uuid_index constant

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomSQLiteOpenHelper.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomSQLiteOpenHelper.java
@@ -33,7 +33,7 @@ class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
 
     private final Context context;
 
-    private final String DROP_INDEX_TRACKS_UUID = "DROP INDEX tracks_uuid_index";
+    private static final String DROP_INDEX_TRACKS_UUID = "DROP INDEX tracks_uuid_index";
 
     public CustomSQLiteOpenHelper(Context context) {
         this(context, ((Startup) context.getApplicationContext()).getDatabaseName());

--- a/src/main/java/de/dennisguse/opentracks/data/CustomSQLiteOpenHelper.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomSQLiteOpenHelper.java
@@ -33,6 +33,8 @@ class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
 
     private final Context context;
 
+    private final String DROP_INDEX_TRACKS_UUID = "DROP INDEX tracks_uuid_index";
+
     public CustomSQLiteOpenHelper(Context context) {
         this(context, ((Startup) context.getApplicationContext()).getDatabaseName());
     }
@@ -200,7 +202,7 @@ class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
     private void downgradeFrom26to25(SQLiteDatabase db) {
         db.beginTransaction();
 
-        db.execSQL("DROP INDEX tracks_uuid_index");
+        db.execSQL(DROP_INDEX_TRACKS_UUID);
 
         db.execSQL("ALTER TABLE tracks RENAME TO tracks_old");
         db.execSQL("CREATE TABLE tracks (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, category TEXT, starttime INTEGER, stoptime INTEGER, numpoints INTEGER, totaldistance FLOAT, totaltime INTEGER, movingtime INTEGER, avgspeed FLOAT, avgmovingspeed FLOAT, maxspeed FLOAT, minelevation FLOAT, maxelevation FLOAT, elevationgain FLOAT, mingrade FLOAT, maxgrade FLOAT, icon TEXT)");
@@ -304,7 +306,7 @@ class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
         db.beginTransaction();
 
         // Tracks
-        db.execSQL("DROP INDEX tracks_uuid_index");
+        db.execSQL(DROP_INDEX_TRACKS_UUID);
 
         db.execSQL("ALTER TABLE tracks RENAME TO tracks_old");
         db.execSQL("CREATE TABLE tracks (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, category TEXT, starttime INTEGER, stoptime INTEGER, numpoints INTEGER, totaldistance FLOAT, totaltime INTEGER, movingtime INTEGER, avgspeed FLOAT, avgmovingspeed FLOAT, maxspeed FLOAT, minelevation FLOAT, maxelevation FLOAT, elevationgain FLOAT, icon TEXT, uuid BLOB)");
@@ -476,7 +478,7 @@ class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
     private void downgradeFrom33to32(SQLiteDatabase db) {
         db.beginTransaction();
 
-        db.execSQL("DROP INDEX tracks_uuid_index");
+        db.execSQL(DROP_INDEX_TRACKS_UUID);
 
         db.execSQL("ALTER TABLE tracks RENAME TO tracks_old");
         db.execSQL("CREATE TABLE tracks (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, category TEXT, starttime INTEGER, stoptime INTEGER, numpoints INTEGER, totaldistance FLOAT, totaltime INTEGER, movingtime INTEGER, avgspeed FLOAT, avgmovingspeed FLOAT, maxspeed FLOAT, minelevation FLOAT, maxelevation FLOAT, elevationgain FLOAT, icon TEXT, uuid BLOB, elevationloss FLOAT)");
@@ -633,7 +635,7 @@ class CustomSQLiteOpenHelper extends SQLiteOpenHelper {
     private void downgradeFrom37to36(SQLiteDatabase db) {
         db.beginTransaction();
 
-        db.execSQL("DROP INDEX tracks_uuid_index");
+        db.execSQL(DROP_INDEX_TRACKS_UUID);
 
         db.execSQL("ALTER TABLE tracks RENAME TO tracks_old");
         db.execSQL("CREATE TABLE tracks (_id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, category TEXT, starttime INTEGER, stoptime INTEGER, numpoints INTEGER, totaldistance FLOAT, totaltime INTEGER, movingtime INTEGER, avgspeed FLOAT, avgmovingspeed FLOAT, maxspeed FLOAT, minelevation FLOAT, maxelevation FLOAT, elevationgain FLOAT, icon TEXT, uuid BLOB, elevationloss FLOAT, starttime_offset INTEGER)");


### PR DESCRIPTION
This PR contains changes to define a constant instead of duplicating this literal "DROP INDEX tracks_uuid_index" 4 times

Source file: src/main/java/de/dennisguse/opentracks/data/CustomSQLiteOpenHelper.java

Link to issue: https://github.com/soen6431-winter25/OpenTracksW25/issues/38
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Define `DROP_INDEX_TRACKS_UUID` constant in `CustomSQLiteOpenHelper` and replace repeated SQL statement with it in four downgrade methods.
> 
>   - **Constants**:
>     - Define `DROP_INDEX_TRACKS_UUID` constant for "DROP INDEX tracks_uuid_index" in `CustomSQLiteOpenHelper`.
>   - **Refactoring**:
>     - Replace literal "DROP INDEX tracks_uuid_index" with `DROP_INDEX_TRACKS_UUID` in `downgradeFrom26to25()`, `downgradeFrom29to28()`, `downgradeFrom33to32()`, and `downgradeFrom37to36()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=soen6431-winter25%2FOpenTracksW25&utm_source=github&utm_medium=referral)<sup> for 48e7a2d2148263b72f4cd3e6ed9ef8c49c4f19a7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->