### PR TITLE
defining a whereclause instead of using where directly in the update …

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -296,6 +296,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
     public int update(@NonNull Uri url, ContentValues values, String where, String[] selectionArgs) {
         // TODO Use SQLiteQueryBuilder
         String table;
+        String whereClause = where;
         SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
 
         switch (getUrlType(url)) {
@@ -324,8 +325,8 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
 
         try {
             db.beginTransaction();
-            count = safeUpdate(db, qb.getTables(),values,where,selectionArgs);
 
+            count = safeUpdate(db, qb.getTables(),values,whereClause,selectionArgs);
             db.setTransactionSuccessful();
         } finally {
             db.endTransaction();
@@ -335,12 +336,8 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
         return count;
     }
     private int safeUpdate(SQLiteDatabase db, String table, ContentValues values,
-                           String where, String[] selectionArgs) {
-        if (TextUtils.isEmpty(where)) {
-            return db.update(table, values, null, null);
-        } else {
-            return db.update(table, values, "(" + where + ")", selectionArgs);
-        }
+                           String whereClause, String[] selectionArgs) {
+            return db.update(table, values, whereClause, selectionArgs);
     }
 
 

--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -241,6 +241,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
         @Override
         public Cursor query(@NonNull Uri url, String[] projection, String selection, String[] selectionArgs, String sort) {
             SQLiteQueryBuilder queryBuilder = new SQLiteQueryBuilder();
+            String constant = " IN (";
             String sortOrder = null;
             switch (getUrlType(url)) {
                 case TRACKPOINTS -> {
@@ -253,7 +254,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
                 }
                 case TRACKPOINTS_BY_TRACKID -> {
                     queryBuilder.setTables(TrackPointsColumns.TABLE_NAME);
-                    queryBuilder.appendWhere(TrackPointsColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
+                    queryBuilder.appendWhere(TrackPointsColumns.TRACKID + constant + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
                 }
                 case TRACKS -> {
                     if (projection != null && Arrays.asList(projection).contains(TracksColumns.MARKER_COUNT)) {
@@ -265,7 +266,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
                 }
                 case TRACKS_BY_ID -> {
                     queryBuilder.setTables(TracksColumns.TABLE_NAME);
-                    queryBuilder.appendWhere(TracksColumns._ID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
+                    queryBuilder.appendWhere(TracksColumns._ID + constant + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
                 }
                 case TRACKS_SENSOR_STATS -> {
                     long trackId = ContentUris.parseId(url);
@@ -281,7 +282,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
                 }
                 case MARKERS_BY_TRACKID -> {
                     queryBuilder.setTables(MarkerColumns.TABLE_NAME);
-                    queryBuilder.appendWhere(MarkerColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
+                    queryBuilder.appendWhere(MarkerColumns.TRACKID + constant + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
                 }
                 default -> throw new IllegalArgumentException("Unknown url " + url);
             }
@@ -294,7 +295,6 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
 
     @Override
     public int update(@NonNull Uri url, ContentValues values, String where, String[] selectionArgs) {
-        // TODO Use SQLiteQueryBuilder
         String table;
         String whereClause = where;
         SQLiteQueryBuilder qb = new SQLiteQueryBuilder();


### PR DESCRIPTION
The first two PRs did not solve the software vulnerability, after running SNYK, the vulnerability is still there. This is attempt number 6.
This PR is about removing software vulnerability using a wrapper function to handle sql injections and a where clause instead of using where 
The path of the file having the issue:
src/main/java/de/dennisguse/opentracks/data /CustomContentProvider.java db.update()
link to the issue https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/82
