### PR TITLE
software vulnerability fix: path traversal #86

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -239,7 +239,7 @@ public class KmzTrackImporter {
         File file = new File(dir, fileName);
         if (!file.toPath().normalize().startsWith(dir.toPath().normalize()))
         {
-            throw new RuntimeException("Bad zip entry: Path Traversal detected");
+            throw new IOException("Bad zip entry: Path Traversal detected");
         }
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java
@@ -237,6 +237,10 @@ public class KmzTrackImporter {
 
         File dir = FileUtils.getPhotoDir(context, trackId);
         File file = new File(dir, fileName);
+        if (!file.toPath().normalize().startsWith(dir.toPath().normalize()))
+        {
+            throw new RuntimeException("Bad zip entry: Path Traversal detected");
+        }
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {


### PR DESCRIPTION
This PR is about removing software vulnerability
The path of the file having the issue:
[src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java](https://github.com/soen6431-winter25/OpenTracksW25/tree/acc303eedabaa0c9a148cb9aaab183db1e3a896d/src/main/java/de/dennisguse/opentracks/io/file/importer/KmzTrackImporter.java#L241)
link to the issue https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/86
