### PR TITLE
Fix SQL injection vulnerability in delete()

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -154,6 +154,9 @@ public class CustomContentProvider extends ContentProvider {
             int deletedRowsFromTable;
             try {
                 db.beginTransaction();
+                if (where != null && !where.matches("^[\\w\\s=?.()]+$")) {
+                    throw new IllegalArgumentException("Unsafe whereClause detected.");
+                }
                 deletedRowsFromTable = db.delete(table, where, selectionArgs);
                 Log.i(TAG, "Deleted " + deletedRowsFromTable + " rows of table " + table);
                 db.setTransactionSuccessful();


### PR DESCRIPTION


PR solving SQL Injection vulnerability in CustomContentProvider in delete()

File location: ‎src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
Line: 157

Description: Unsanitized input from a Content Provider selection (WHERE) parameter flows into delete, where it is used in an SQL query. This may result in an SQL Injection vulnerability.

Fixes applied:

    Regex Pattern: ^[\w\s=?.()]+$
    Allows: word characters, spaces, =, ?, ., (, )
    Blocks: dangerous symbols like ;, ', ", --, etc.

This ensures the WHERE is made of safe patterns.
