### PR TITLE
Fix SQL vulnerability in db.delete()

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -153,6 +153,9 @@ public class CustomContentProvider extends ContentProvider {
             int totalChangesBefore = getTotalChanges();
             int deletedRowsFromTable;
             try {
+                if (where != null && where.matches(  "(--|;|/\\*|\\*/|\\b(OR|AND|DROP|DELETE|INSERT|UPDATE|UNION|SELECT|EXEC|ALTER|CREATE)\\b)")) {
+                    throw new IllegalArgumentException("Potentially unsafe WHERE clause detected: " + where);
+                }
                 db.beginTransaction();
                 deletedRowsFromTable = db.delete(table, where, selectionArgs);
                 Log.i(TAG, "Deleted " + deletedRowsFromTable + " rows of table " + table);


### PR DESCRIPTION
PR solving SQL Injection vulnerability in CustomContentProvider in delete()

File location: ‎src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
Line: 157

Description: Unsanitized input from a Content Provider selection (WHERE) parameter flows into delete, where it is used in an SQL query. This may result in an SQL Injection vulnerability.

Fixes applied: regex pattern matching "(--|;|/\\*|\\*/|\\b(OR|AND|DROP|DELETE|INSERT|UPDATE|UNION|SELECT|EXEC|ALTER|CREATE)\\b)"