### PR TITLE
Fix SQL vulnerability in db.delete()

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -150,14 +150,14 @@ public class CustomContentProvider extends ContentProvider {
             };
     
             Log.w(TAG, "Deleting from table " + table);
+
+
+
             int totalChangesBefore = getTotalChanges();
             int deletedRowsFromTable;
             try {
-                if (where != null && where.matches(  "(--|;|/\\*|\\*/|\\b(OR|AND|DROP|DELETE|INSERT|UPDATE|UNION|SELECT|EXEC|ALTER|CREATE)\\b)")) {
-                    throw new IllegalArgumentException("Potentially unsafe WHERE clause detected: " + where);
-                }
                 db.beginTransaction();
-                deletedRowsFromTable = db.delete(table, where, selectionArgs);
+                deletedRowsFromTable = db.delete(table, where, getSafeSelectionArgs(selectionArgs));
                 Log.i(TAG, "Deleted " + deletedRowsFromTable + " rows of table " + table);
                 db.setTransactionSuccessful();
             } finally {


### PR DESCRIPTION
Issue Type: Software Vulnerability

Location: [src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java](https://github.com/soen6431-winter25/OpenTracksW25/tree/b5a30dbc8ff241978bcaba7847703bc62b382810/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java#L157)

Lines affected: 157

Score: 574

Issue detected by Snyk
Issue Link in Snyk: https://app.snyk.io/org/eileenfu/project/341cf547-40b3-49c7-8bde-db691c6712f5/history/01312c8b-7ea6-435f-8cf2-434408a08a81#issue-7f6a2df8-9658-4267-ac74-ef5a3a5ce88c

Description:
Unsanitized input from a Content Provider selection (WHERE) parameter flows into delete, where it is used in an SQL query. This may result in an SQL Injection vulnerability.

Type of Vulnerability:
SQL Injection
