### PR TITLE
Fix Anroid Intent Forwarding on line 193

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -188,8 +188,13 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
         }
 
         if (item.getItemId() == R.id.track_detail_edit) {
-            Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
+            if (trackId == null) {
+                Log.e(TAG, "Track ID is null. Cannot proceed with resuming the track.");
+                return false;
+            }
+            Intent intent = new Intent(this, TrackEditActivity.class)
                     .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackId);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
             return true;
         }


### PR DESCRIPTION
Issue Type: Software Vulnerability

Location: [src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java](https://github.com/soen6431-winter25/OpenTracksW25/tree/3983bc3845a3d7257c81a7af406a18cabe2b85fb/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java#L193)

Lines affected: Line 193

Score: 620

Issue detected by Snyk
Issue Link in Snyk: https://app.snyk.io/org/eileenfu/project/341cf547-40b3-49c7-8bde-db691c6712f5#issue-07ea5cf3-d423-42fe-840f-babd577b9086

Description:
Unsanitized input from Activity.getIntent() flows into startActivity where it is used to start an Activity. If the Android component where the Intent was acquired is exported and the Intent originates from a third-party application, this could provide the third-party application access to unauthorised functionality or data within the target application.

Type of Vulnerability:
Android Intent Forwarding
