### PR TITLE
Fix for Android intent forwarding in TrackRecordingActivity.java

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordingActivity.java
@@ -140,8 +140,11 @@ public class TrackRecordingActivity extends AbstractActivity implements ChooseAc
         viewBinding.trackRecordingFabAction.setOnLongClickListener((view) -> {
             ActivityUtils.vibrate(this, Duration.ofSeconds(1));
             trackRecordingServiceConnection.stopRecording(TrackRecordingActivity.this);
-            Intent newIntent = IntentUtils.newIntent(TrackRecordingActivity.this, TrackStoppedActivity.class)
-                    .putExtra(TrackStoppedActivity.EXTRA_TRACK_ID, trackId);
+
+            Intent newIntent = new Intent(TrackRecordingActivity.this, TrackStoppedActivity.class);
+            newIntent.putExtra(TrackStoppedActivity.EXTRA_TRACK_ID, trackId);
+            newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
             startActivity(newIntent);
             overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             finish();


### PR DESCRIPTION
This PR aims to resolve android intent forwarding issue detected by Snyk for TrackRecordingActivity.java

Link to issue:
https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/110

![image](https://github.com/user-attachments/assets/58961929-3c87-4608-8bcd-49bc54bca6d6)
